### PR TITLE
Added module config

### DIFF
--- a/n98-magerun.yaml
+++ b/n98-magerun.yaml
@@ -1,0 +1,6 @@
+autoloaders:
+  KJ: %module%/src
+
+commands:
+  customCommands:
+    - KJ\Magento\Command\Design\RefreshCommand


### PR DESCRIPTION
I added a new config which registrates the command in n98-magerun.

Clone your repostory to folder:

`/usr/local/share/n98-magerun/modules/`

Currently i'm working on a feature to define own module base folders.
You can test the module function in current develop branch.
Update with `n98-magerun.phar self-updte --unstable`
