### PR TITLE
Advanced Theme Diff Summary

### DIFF
--- a/src/KJ/Magento/Command/Diff/ThemeCommand.php
+++ b/src/KJ/Magento/Command/Diff/ThemeCommand.php
@@ -20,6 +20,7 @@ class ThemeCommand extends AbstractCommand
             ->addArgument('pattern', InputArgument::OPTIONAL, 'List details for any file with a diff that matches on this pattern')
             ->addOption('lines', null, InputOption::VALUE_OPTIONAL, 'The number of lines of context in the diff', 3)
             ->addOption('ignore-copyright', null, InputOption::VALUE_NONE, 'If set, lines containing "@license" and "@copyright" are ignored')
+            ->addOption('filter', null, InputOption::VALUE_OPTIONAL, "Possible values:\n\tonly-different: only files with >0 found differences will be shown in summary\n\tonly-equal: only files with 0 found differences will be shown in summary")
             ->addOption('pro', null, InputOption::VALUE_OPTIONAL, 'If this parameter is passed, it will check pro instead of ee')
             ->setDescription('Diff the theme to detect changes.');
     }
@@ -41,6 +42,7 @@ class ThemeCommand extends AbstractCommand
         if ($this->_input->getOption('ignore-copyright')) {
             $comparison->setAdditionalParameters("-I '@license .*' -I '@copyright *Copyright .* Inc'");
         }
+        $comparison->setFilter($this->_input->getOption('filter'));
 
         $comparison->setMagentoInstanceRootDirectory($this->_magentoRootFolder)
             ->setCurrentTheme($this->_getCurrentTheme())

--- a/src/KJ/Magento/Command/Diff/ThemeCommand.php
+++ b/src/KJ/Magento/Command/Diff/ThemeCommand.php
@@ -19,6 +19,7 @@ class ThemeCommand extends AbstractCommand
             ->addArgument('theme-to-compare-against', InputArgument::REQUIRED, 'Which theme to diff against', null)
             ->addArgument('pattern', InputArgument::OPTIONAL, 'List details for any file with a diff that matches on this pattern')
             ->addOption('lines', null, InputOption::VALUE_OPTIONAL, 'The number of lines of context in the diff', 3)
+            ->addOption('ignore-copyright', null, InputOption::VALUE_NONE, 'If set, lines containing "@license" and "@copyright" are ignored')
             ->addOption('pro', null, InputOption::VALUE_OPTIONAL, 'If this parameter is passed, it will check pro instead of ee')
             ->setDescription('Diff the theme to detect changes.');
     }
@@ -36,6 +37,9 @@ class ThemeCommand extends AbstractCommand
 
         if ($this->_input->getOption('lines')) {
             $comparison->setLinesOfContext($this->_input->getOption('lines'));
+        }
+        if ($this->_input->getOption('ignore-copyright')) {
+            $comparison->setAdditionalParameters("-I '@license .*' -I '@copyright *Copyright .* Inc'");
         }
 
         $comparison->setMagentoInstanceRootDirectory($this->_magentoRootFolder)

--- a/src/KJ/Magento/Command/Diff/ThemeCommand.php
+++ b/src/KJ/Magento/Command/Diff/ThemeCommand.php
@@ -66,7 +66,7 @@ class ThemeCommand extends AbstractCommand
     protected function _outputComparisonSummary($comparison)
     {
         $this->getHelper('table')
-            ->setHeaders(array('File'))
+            ->setHeaders(array('File', 'Differences'))
             ->setRows($comparison->getSummary())
             ->render($this->_output);
     }

--- a/src/KJ/Magento/Command/Diff/ThemeCommand.php
+++ b/src/KJ/Magento/Command/Diff/ThemeCommand.php
@@ -18,6 +18,7 @@ class ThemeCommand extends AbstractCommand
             ->addArgument('current-theme', InputArgument::REQUIRED, 'Current theme', null)
             ->addArgument('theme-to-compare-against', InputArgument::REQUIRED, 'Which theme to diff against', null)
             ->addArgument('pattern', InputArgument::OPTIONAL, 'List details for any file with a diff that matches on this pattern')
+            ->addOption('raw', null, InputOption::VALUE_NONE, 'If set, the summary outputs only file names, without table decoration')
             ->addOption('lines', null, InputOption::VALUE_OPTIONAL, 'The number of lines of context in the diff', 3)
             ->addOption('ignore-copyright', null, InputOption::VALUE_NONE, 'If set, lines containing "@license" and "@copyright" are ignored')
             ->addOption('filter', null, InputOption::VALUE_OPTIONAL, "Possible values:\n\tonly-different: only files with >0 found differences will be shown in summary\n\tonly-equal: only files with 0 found differences will be shown in summary")
@@ -31,8 +32,10 @@ class ThemeCommand extends AbstractCommand
         $this->_output = $output;
 
         $this->initMagento();
-        $this->_info(sprintf('Magento Version is %s', $this->getCurrentVersion()));
-        $this->_info(sprintf('Comparing current theme %s to %s', $this->_getCurrentTheme(), $this->_getThemeToCompareAgainst()));
+        if (!$this->_input->getOption('raw')) {
+            $this->_info(sprintf('Magento Version is %s', $this->getCurrentVersion()));
+            $this->_info(sprintf('Comparing current theme %s to %s', $this->_getCurrentTheme(), $this->_getThemeToCompareAgainst()));
+        }
 
         $comparison = new \KJ\Magento\Util\ThemeComparison($input, $output);
 
@@ -71,10 +74,16 @@ class ThemeCommand extends AbstractCommand
      */
     protected function _outputComparisonSummary($comparison)
     {
-        $this->getHelper('table')
-            ->setHeaders(array('File', 'Differences'))
-            ->setRows($comparison->getSummary())
-            ->render($this->_output);
+        if ($this->_input->getOption('raw')) {
+            foreach ($comparison->getSummary() as $item) {
+                $this->_output->writeln($item['file']);
+            }
+        } else {
+            $this->getHelper('table')
+                ->setHeaders(array('File', 'Differences'))
+                ->setRows($comparison->getSummary())
+                ->render($this->_output);
+        }
     }
 
     /**

--- a/src/KJ/Magento/Command/Diff/ThemeCommand.php
+++ b/src/KJ/Magento/Command/Diff/ThemeCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ThemeCommand extends AbstractCommand
 {
-    protected $_version = null;
 
     protected function configure()
     {
@@ -30,7 +29,7 @@ class ThemeCommand extends AbstractCommand
         $this->_output = $output;
 
         $this->initMagento();
-        $this->_info(sprintf('Magento Version is %s', $version));
+        $this->_info(sprintf('Magento Version is %s', $this->getCurrentVersion()));
         $this->_info(sprintf('Comparing current theme %s to %s', $this->_getCurrentTheme(), $this->_getThemeToCompareAgainst()));
 
         $comparison = new \KJ\Magento\Util\ThemeComparison($input, $output);

--- a/src/KJ/Magento/Util/AbstractComparison.php
+++ b/src/KJ/Magento/Util/AbstractComparison.php
@@ -14,6 +14,8 @@ class AbstractComparison extends AbstractUtil
 
     protected $_linesOfContext;
 
+    protected $_additionalParameters = '';
+
     public function __construct($input, $output)
     {
         $this->_input = $input;
@@ -56,5 +58,15 @@ class AbstractComparison extends AbstractUtil
         }
 
         return 3;
+    }
+
+    public function setAdditionalParameters($paramString)
+    {
+        $this->_additionalParameters = $paramString;
+    }
+
+    public function getAdditionalParameters()
+    {
+        return $this->_additionalParameters;
     }
 }

--- a/src/KJ/Magento/Util/AbstractComparison.php
+++ b/src/KJ/Magento/Util/AbstractComparison.php
@@ -2,6 +2,8 @@
 
 namespace KJ\Magento\Util;
 
+use KJ\Magento\Util\Comparison\Filter;
+
 class AbstractComparison extends AbstractUtil
 {
     /** @var InputInterface $input */
@@ -9,6 +11,11 @@ class AbstractComparison extends AbstractUtil
 
     /** @var OutputInterface $output  */
     protected $_output;
+
+    /**
+     * @var Filter
+     */
+    protected $_filter;
 
     protected $_magentoInstanceRootDirectory;
 
@@ -68,5 +75,15 @@ class AbstractComparison extends AbstractUtil
     public function getAdditionalParameters()
     {
         return $this->_additionalParameters;
+    }
+
+    public function setFilter($filter)
+    {
+        $this->_filter = Filter::factory($filter);
+    }
+
+    public function getFilter($filter)
+    {
+        return $this->_filter;
     }
 }

--- a/src/KJ/Magento/Util/Comparison/Filter.php
+++ b/src/KJ/Magento/Util/Comparison/Filter.php
@@ -1,0 +1,40 @@
+<?php
+namespace KJ\Magento\Util\Comparison;
+
+use KJ\Magento\Util\Comparison\Filter\OnlyDifferent;
+use KJ\Magento\Util\Comparison\Filter\OnlyEqual;
+use KJ\Magento\Util\Comparison\Filter\Null;
+use KJ\Magento\Util\ThemeComparison\AbstractThemeComparisonItem;
+
+abstract class Filter
+{
+    const NONE = 'none';
+    const ONLY_DIFFERENT = 'only-different';
+    const ONLY_EQUAL = 'only-equal';
+
+    /**
+     * Abstract factory
+     *
+     * @param $value
+     * @return Filter
+     */
+    public static function factory($value)
+    {
+        switch ($value) {
+            case self::ONLY_DIFFERENT:
+                return new OnlyDifferent();
+            case self::ONLY_EQUAL:
+                return new OnlyEqual();
+            default:
+                return new Null();
+        }
+    }
+
+    /**
+     * Return true if item should be included in filtered result
+     *
+     * @param AbstractThemeComparisonItem $item
+     * @return bool
+     */
+    abstract public function filterItem(AbstractThemeComparisonItem $item);
+}

--- a/src/KJ/Magento/Util/Comparison/Filter/Null.php
+++ b/src/KJ/Magento/Util/Comparison/Filter/Null.php
@@ -1,0 +1,20 @@
+<?php
+namespace KJ\Magento\Util\Comparison\Filter;
+
+use KJ\Magento\Util\Comparison\Filter;
+use KJ\Magento\Util\ThemeComparison\AbstractThemeComparisonItem;
+
+class Null extends Filter
+{
+    /**
+     * Return true if item should be included in filtered result
+     *
+     * @param AbstractThemeComparisonItem $item
+     * @return bool
+     */
+    public function filterItem(AbstractThemeComparisonItem $item)
+    {
+        return true;
+    }
+
+}

--- a/src/KJ/Magento/Util/Comparison/Filter/OnlyDifferent.php
+++ b/src/KJ/Magento/Util/Comparison/Filter/OnlyDifferent.php
@@ -1,0 +1,20 @@
+<?php
+namespace KJ\Magento\Util\Comparison\Filter;
+
+use KJ\Magento\Util\Comparison\Filter;
+use KJ\Magento\Util\ThemeComparison\AbstractThemeComparisonItem;
+
+class OnlyDifferent extends Filter
+{
+    /**
+     * Return true if item should be included in filtered result
+     *
+     * @param AbstractThemeComparisonItem $item
+     * @return bool
+     */
+    public function filterItem(AbstractThemeComparisonItem $item)
+    {
+        return $item->getNumberOfDifferences() > 0;
+    }
+
+}

--- a/src/KJ/Magento/Util/Comparison/Filter/OnlyEqual.php
+++ b/src/KJ/Magento/Util/Comparison/Filter/OnlyEqual.php
@@ -1,0 +1,20 @@
+<?php
+namespace KJ\Magento\Util\Comparison\Filter;
+
+use KJ\Magento\Util\Comparison\Filter;
+use KJ\Magento\Util\ThemeComparison\AbstractThemeComparisonItem;
+
+class OnlyEqual extends Filter
+{
+    /**
+     * Return true if item should be included in filtered result
+     *
+     * @param AbstractThemeComparisonItem $item
+     * @return bool
+     */
+    public function filterItem(AbstractThemeComparisonItem $item)
+    {
+        return $item->getNumberOfDifferences() === 0;
+    }
+
+}

--- a/src/KJ/Magento/Util/Comparison/Item/Line.php
+++ b/src/KJ/Magento/Util/Comparison/Item/Line.php
@@ -21,7 +21,7 @@ class Line extends \KJ\Magento\Util\AbstractUtil
             return false;
         }
 
-        if ($this->_isFileNameLine($line)) {
+        if ($this->_isFileNameLine($this->_rawLine)) {
             return false;
         }
 

--- a/src/KJ/Magento/Util/ThemeComparison.php
+++ b/src/KJ/Magento/Util/ThemeComparison.php
@@ -114,6 +114,9 @@ class ThemeComparison extends AbstractComparison
         $filenames = array();
 
         foreach ($this->_changedLayoutFiles as $comparisonItem) {
+            if (!$this->_filter->filterItem($comparisonItem)) {
+                continue;
+            }
             $filenames[] = array(
                 'file'        => $comparisonItem->getFileName(),
                 'differences' => $comparisonItem->getNumberOfDifferences()
@@ -121,6 +124,9 @@ class ThemeComparison extends AbstractComparison
         }
 
         foreach ($this->_changedTemplateFiles as $comparisonItem) {
+            if (!$this->_filter->filterItem($comparisonItem)) {
+                continue;
+            }
             $filenames[] = array(
                 'file'        => $comparisonItem->getFileName(),
                 'differences' => $comparisonItem->getNumberOfDifferences()

--- a/src/KJ/Magento/Util/ThemeComparison.php
+++ b/src/KJ/Magento/Util/ThemeComparison.php
@@ -2,14 +2,22 @@
 
 namespace KJ\Magento\Util;
 
+use KJ\Magento\Util\ThemeComparison\LayoutItem;
+use KJ\Magento\Util\ThemeComparison\TemplateItem;
+
 class ThemeComparison extends AbstractComparison
 {
     protected $_currentTheme;
 
     protected $_themeToCompareAgainst;
 
+    /**
+     * @var LayoutItem[]
+     */
     protected $_changedLayoutFiles = array();
-
+    /**
+     * @var TemplateItem[]
+     */
     protected $_changedTemplateFiles = array();
 
     protected $_magentoInstanceRootDirectory;
@@ -107,13 +115,15 @@ class ThemeComparison extends AbstractComparison
 
         foreach ($this->_changedLayoutFiles as $comparisonItem) {
             $filenames[] = array(
-                'file' => $comparisonItem->getFileName()
+                'file'        => $comparisonItem->getFileName(),
+                'differences' => $comparisonItem->getNumberOfDifferences()
             );
         }
 
         foreach ($this->_changedTemplateFiles as $comparisonItem) {
             $filenames[] = array(
-                'file' => $comparisonItem->getFileName()
+                'file'        => $comparisonItem->getFileName(),
+                'differences' => $comparisonItem->getNumberOfDifferences()
             );
         }
 

--- a/src/KJ/Magento/Util/ThemeComparison/AbstractThemeComparisonItem.php
+++ b/src/KJ/Magento/Util/ThemeComparison/AbstractThemeComparisonItem.php
@@ -14,6 +14,8 @@ class AbstractThemeComparisonItem extends \KJ\Magento\Util\AbstractUtil
     /** @var  \KJ\Magento\Util\ThemeComparison */
     protected $_comparison;
 
+    protected $_diffResult;
+
     /**
      * @param $file \Symfony\Component\Finder\SplFileInfo
      */
@@ -87,6 +89,9 @@ class AbstractThemeComparisonItem extends \KJ\Magento\Util\AbstractUtil
 
     public function getDiff()
     {
+        if ($this->_diffResult !== null) {
+            return $this->_diffResult;
+        }
         $fromFileFullPath = $this->_getAbsoluteFilePathToCompareAgainst();
         $toFileFullPath = $this->_getAbsoluteFilePath();
 
@@ -106,8 +111,15 @@ class AbstractThemeComparisonItem extends \KJ\Magento\Util\AbstractUtil
                 $this->_numberOfDifferences++;
             }
         }
+        $this->_diffResult = $lines;
 
         return $lines;
+    }
+
+    public function getNumberOfDifferences()
+    {
+        $this->getDiff();
+        return $this->_numberOfDifferences;
     }
 
     public function fileToCompareAgainstExists()

--- a/src/KJ/Magento/Util/ThemeComparison/AbstractThemeComparisonItem.php
+++ b/src/KJ/Magento/Util/ThemeComparison/AbstractThemeComparisonItem.php
@@ -96,7 +96,9 @@ class AbstractThemeComparisonItem extends \KJ\Magento\Util\AbstractUtil
         $toFileFullPath = $this->_getAbsoluteFilePath();
 
         $context = $this->_comparison->getLinesOfContext();
-        $lines = $this->_executeShellCommand(sprintf('diff -U%s -w %s %s', $context, $fromFileFullPath, $toFileFullPath));
+        $additionalParameters = $this->_comparison->getAdditionalParameters();
+        $lines = $this->_executeShellCommand(sprintf('diff -U%s %s -w %s %s',
+            $context, $additionalParameters, $fromFileFullPath, $toFileFullPath));
 
         foreach ($lines as & $line) {
             $comparisonItemLine = new \KJ\Magento\Util\Comparison\Item\Line($line);


### PR DESCRIPTION
Extended the summary of the diff:theme command to show the number of differences, optionally ignore `@licence` and `@copyright` lines, allow filtering by equal or non-equal files and add raw output option for piping.