### PR TITLE
Change composer type + modman file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kalenjordan/magerun-addons",
-    "type": "library",
+    "type": "magento-module",
     "description": "Addon commands for N98 MageRun",
     "keywords": ["magerun"],
     "homepage": "https://github.com/kalenjordan/magerun-addons",
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "magento-hackathon/magento-composer-installer": "*",
         "php": ">=5.3.0"
     },
     "require-dev": {

--- a/modman
+++ b/modman
@@ -1,0 +1,2 @@
+src       lib/n98-magerun/modules/Kalenjordan_MagerunAddons/src/
+n98-magerun.yaml    lib/n98-magerun/modules/Kalenjordan_MagerunAddons/n98-magerun.yaml


### PR DESCRIPTION
Changes with this pull requrest:
- convert composer type for magento composer install 
- add modman file for magento source

In many cases I include this addons directly into magento source (/lib folder), so I need composer installer and modman to do that (I don't want to make it manually).

Hope this can help!
