### PR TITLE
Added param for list domains for which email addresses will be left untouched

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Assigns the order #10000000001 to customer ID 10.
 Anonymize customer email addresses across a bunch of tables: order, order address, newsletter, quotes,
 newsletter subscriber.
 
-    $ mr customer:anon
+Optionally you can pass a comma separated list of domain for which email addresses will be left untouched.
+
+    $ mr customer:anon [--whitelist="example.com,dummy.net,..."]
 
 ### Core file diff ###
 

--- a/src/KJ/Magento/Command/Customer/AnonymizeCommand.php
+++ b/src/KJ/Magento/Command/Customer/AnonymizeCommand.php
@@ -20,6 +20,7 @@ class AnonymizeCommand extends \N98\Magento\Command\AbstractMagentoCommand
     {
         $this
             ->setName('customer:anon')
+            ->addOption('whitelist', null, InputOption::VALUE_OPTIONAL, "A comma separated list of domains for which email addresses will be left untouched")
             ->setDescription('Strip all email addresses from customer tables.')
         ;
     }
@@ -54,6 +55,14 @@ class AnonymizeCommand extends \N98\Magento\Command\AbstractMagentoCommand
         $query = "update $tableName set $emailColumn = " .
                  "concat('test+',SUBSTRING(SHA1(CONCAT($emailColumn,'$salt')) FROM 1 FOR 10),'@example.com') " .
                  "where $emailColumn not like 'test+%;'";
+
+        if ($this->_input->getOption('whitelist')) {
+            $whitelistDomains = explode(',', $this->_input->getOption('whitelist'));
+            
+            foreach ($whitelistDomains as $domain) {
+                $query .= " AND $emailColumn not like '%@" . $domain . "'";
+            }
+        }
 
         $connection->query($query);
 


### PR DESCRIPTION
When we stage the database from production to QA/UAT environment, we of course need to anonymize at least email addresses, but something we want to preserve those belonging to merchant staff and dev team, that are used for tests.

This PR introduce a little param that let to pass a list of domains for which email addresses will be left untouched.